### PR TITLE
Add cerebral-react-immutable-store peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/christianalfoni/cerebral-react-baobab",
   "peerDependencies": {
     "react": "^0.13.3",
-    "baobab": "^2.0.0-dev13"
+    "baobab": "^2.0.0-dev13",
+    "cerebral-react-immutable-store": "^0.5.1" 
   },
   "dependencies": {
     "cerebral": "^0.14.0"


### PR DESCRIPTION
Since [we are now recomended to import this package](https://github.com/christianalfoni/cerebral-react-baobab/commit/04f7d574370df670aab194048215accb3aff9908#diff-04c6e90faac2675aa89e2176d2eec7d8R114) it seems to make sense to include it as a peer dependency.
